### PR TITLE
Correct np.newaxis in mt_deconv

### DIFF
--- a/multitaper/mtcross.py
+++ b/multitaper/mtcross.py
@@ -345,7 +345,7 @@ class MTCross:
 
         dfun  = scipy.fft.ifft(trf[:,0],nfft) 
         dfun  = np.real(scipy.fft.fftshift(dfun))
-        dfun  = dfun[:,np.nexaxis]
+        dfun  = dfun[:,np.newaxis]
         dfun  = dfun/float(nfft) 
 
         return dfun 


### PR DESCRIPTION
Small error in mt_deconv: dfun  = dfun[:,np.nexaxis]
Returns numpy error. Changed to dfun  = dfun[:,np.newaxis]