### PR TITLE
add numba for performance increase

### DIFF
--- a/multitaper/mtspec.py
+++ b/multitaper/mtspec.py
@@ -181,7 +181,7 @@ class MTSpec:
         #-----------------------------------------------------
 
         if (kspec < 1):
-            kspec = np.int(np.round(2*nw-1))
+            kspec = int(np.round(2*nw-1))
 
         #-----------------------------------------------------
         # Check dimensions of input vector
@@ -219,7 +219,7 @@ class MTSpec:
         # Define other parameters (nfft, nf, freq vector)
         #-----------------------------------------------------------------
        
-        nfft = np.int(nfft)
+        nfft = int(nfft)
         if (nfft < npts):
             nfft = 2*npts + 1
         if (nfft%2 == 0):
@@ -781,7 +781,7 @@ class MTSine:
             nf     = int(npts/2+1)
         else:
             nf     = int((npts+1)/2) 
-        nfft       = np.int(2*npts)
+        nfft       = int(2*npts)
         freq       = scipy.fft.rfftfreq(npts,dt)
         df         = freq[2]-freq[1]
         freq       = freq[:, np.newaxis]

--- a/multitaper/utils.py
+++ b/multitaper/utils.py
@@ -403,7 +403,7 @@ def dpss(npts,nw,kspec=None):
     W = nw/float(npts)
 
     if (kspec is None):
-       kspec = np.int(np.round(2*nw-1))
+       kspec = int(np.round(2*nw-1))
 
     #-----------------------------------------------------
     # Get the DPSS, using SCIPY 
@@ -521,7 +521,7 @@ def dpss2(npts,nw,nev=None):
     bw = nw/float(npts)
 
     if (nev is None):
-       nev = np.int(np.round(2*nw-1))
+       nev = int(np.round(2*nw-1))
 
     #-----------------------------------------------------
     # Check size of vectors and half lengths

--- a/multitaper/utils.py
+++ b/multitaper/utils.py
@@ -40,13 +40,14 @@ import scipy.linalg as linalg
 import scipy.interpolate as interp
 import scipy.optimize as optim
 import os
-
+from numba import njit
 
 
 #-------------------------------------------------------------------------
 # SET_XINT - Set up weights and sample points for Ierly quadrature
 #-------------------------------------------------------------------------
 
+@njit(cache=True)
 def set_xint(ising):
     """
     Sets up weights and sample points for Ierley quadrature,
@@ -129,6 +130,7 @@ def set_xint(ising):
 # XINT - Numerical integration in the Fourier Domain using Ierly's method
 #-------------------------------------------------------------------------
 
+@njit(cache=True)
 def xint(a,b,tol,vn,npts):
     """
     Quadrature by Ierley's method of Chebychev sampling.
@@ -201,9 +203,6 @@ def xint(a,b,tol,vn,npts):
     #--------------------------- 
     #   Check tol
     #---------------------------
-
-    if (tol <= 0.0):
-        raise ValueError("In xint tol must be > 0 ", tol)
 
     est = np.zeros(nomx,dtype=float)
     fv  = np.zeros(lomx+1,dtype=float)
@@ -1763,6 +1762,7 @@ def df_spec_old(x,y=None,fmin=None,fmax=None):
 # SFT - slow fourier transform
 #-------------------------------------------------------------------------
 
+@njit
 def sft(x,om):
     """
     calculates the (slow) fourier transform of real 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
         ]
     },
     python_requires=">=3.7",
+    install_requires=['numpy', 'scipy', 'numba'],
+
 )
 
 


### PR DESCRIPTION
Use @njit decorators to for `xint` `set_xint` and `sft` functions.

Additional changes:

- Needed to remove the tolerance checker in `xint`
- Changed np.int to int due to a [DeprecationWarning](https://numpy.org/devdocs/release/1.20.0-notes.html) for NumPy >=1.20 