### PR TITLE
Fix "setting an array element with a sequence" error for newer NumPy

### DIFF
--- a/multitaper/utils.py
+++ b/multitaper/utils.py
@@ -1239,7 +1239,7 @@ def qiinv(spec,yk,wt,vn,lamb,nw):
        #---------------------------------------------
        cte_out  = optim.nnls(np.real(h1), 
                              np.real(Cjk[:,0]))[0]
-       cte2[i]  = np.real(cte_out) 
+       cte2[i]  = np.real(cte_out).squeeze()
        pred = h1*cte2[i]
        Cjk2 = Cjk-pred
        #---------------------------------------------
@@ -1247,9 +1247,9 @@ def qiinv(spec,yk,wt,vn,lamb,nw):
        #---------------------------------------------
        btilde    = np.matmul(Qt,Cjk2) 
        hmodel,res,rnk,s = scipy.linalg.lstsq(R,btilde)
-       cte[i]   = np.real(hmodel[0])
-       slope[i] = -np.real(hmodel[1])
-       quad[i]  = np.real(hmodel[2])
+       cte[i]   = np.real(hmodel[0]).squeeze()
+       slope[i] = -np.real(hmodel[1]).squeeze()
+       quad[i]  = np.real(hmodel[2]).squeeze()
 
        pred = np.matmul(hk,np.real(hmodel))
        sigma2[i] = np.sum(np.abs(Cjk2-pred)**2)/(L-nh) 


### PR DESCRIPTION
This PR fixes an issue where "setting an array element with a sequence" errors would appear for newer NumPy versions. With the changes in this PR, `multitaper` [`mtspec.MTSpec`](https://multitaper.readthedocs.io/en/latest/mtspec.html#mtspec.MTSpec) and [`mtspec.spectrogram`](https://multitaper.readthedocs.io/en/latest/mtspec.html#mtspec.spectrogram) both work on installs with the following versions:
| Tool | Version | 
| :----- | :------- |
| Python | 3.14 |
| NumPy | 2.4.3 |
| SciPy | 1.17.1 |
| Numba | 0.65.1 |

The above versions are what I obtained by running
```shell
mamba create --name mtspec numba scipy
```
on 5 May 2026. I installed `multitaper` via
```shell
mamba activate mtspec
pip install --editable .
```
The specific code I tried was
```python
from multitaper import mtspec
x = np.random.randn(256)
mtspec.MTSpec(x)
mtspec.spectrogram(x, dt=0.1, twin=1)
```